### PR TITLE
Includes temporal measurements

### DIFF
--- a/config/debugging-measurement-times.json
+++ b/config/debugging-measurement-times.json
@@ -1,0 +1,18 @@
+{
+    "simulation-name": "debugging-measurement-times",
+    "output-hdf5": "dataset-demo.hdf5",
+    "seed": 42,
+    "remaster-xml": "src/remaster-template.xml",
+    "num-simulations": 20,
+    "num-workers": 3,
+    "simulation-hyperparameters": {
+	"duration-range": [20, 40],
+	"num-changes": [1, 2],
+	"shrinkage-factor": 0.99,
+	"r0_bounds": [1.4, 1.6],
+	"net_rem_rate_bounds": [6.5, 7.5],
+	"sampling_prop_bounds": [0.10, 0.30],
+    "report-temporal-data": true,
+    "num-temp-measurements": 10
+    }
+}

--- a/config/readme.org
+++ b/config/readme.org
@@ -12,6 +12,13 @@
   sampling proportion given removal. If there is a contemporaneous
   sample, this is the probability of an extant lineage being included
   in the sample.
+- =simulation-hyperparameters.report-temporal-data= can be set to
+  =true= in order to capture temporal data from the simulation in the
+  resulting database (=false= by default). If this parameter is set
+  to =true=, =simulation-hyperparameters.num-temp-measurements= (an
+  =integer=) must also be specified. This is the number of randomly
+  selected time points between the start of the epidemic and the
+  present at which data is reported.
 
 ** Schema
 
@@ -101,6 +108,12 @@
         },
         "contemporaneous_sample": {
           "type": "boolean"
+        },
+        "report-temporal-data": {
+            "type": "boolean"
+        },
+        "num-temp-measurements": {
+            "type": "integer"
         }
       },
       "required": [

--- a/config/simulation-schema.json
+++ b/config/simulation-schema.json
@@ -83,6 +83,12 @@
         },
         "contemporaneous_sample": {
           "type": "boolean"
+        },
+        "report-temporal-data": {
+            "type": "boolean"
+        },
+        "num-temp-measurements": {
+            "type": "integer"
         }
       },
       "required": [

--- a/main.py
+++ b/main.py
@@ -300,7 +300,16 @@ def run_beast2_simulations_parallel(simulation_xml_list, num_jobs):
         $ ./lib/beast/bin/beast -seed 1 -overwrite <simulation_xml>
         """
         print(f"Running simulation: {simulation_xml}")
-        command = ["/Applications/BEAST 2.7.6/bin/beast", "-seed", "1", "-overwrite", simulation_xml]
+        # MODIFIED 28-8: following AZ comment, gives mac and linux compatability
+        beast_executable_mac = "/Applications/BEAST 2.7.6/bin/beast"
+        beast_executable_linux = "./lib/beast/bin/beast"
+        if os.path.exists(beast_executable_mac):
+            beast_executable = beast_executable_mac
+        elif os.path.exists(beast_executable_linux):
+            beast_executable = beast_executable_linux
+        else:
+            raise Exception("BEAST2 executable not found.")
+        command = [beast_executable, "-seed", "1", "-overwrite", simulation_xml]
         try:
             result = subprocess.run(
                 command, check=True, capture_output=True, text=True, timeout=300,
@@ -372,7 +381,7 @@ def read_simulation_results(simulation_xml, params):
         
             this_meas_time = meas_times[time_ind]
         
-            most_recent_obs_time = traj_df[traj_df["t"] >= this_meas_time]["t"].min()
+            most_recent_change_time = traj_df[traj_df["t"] <= this_meas_time]["t"].max()
             rows_this_time = traj_df[traj_df["t"] == most_recent_obs_time]
             this_X = rows_this_time[rows_this_time["population"] == "X"]["value"].values[0]
             this_Psi = rows_this_time[rows_this_time["population"] == "Psi"]["value"].values[0]

--- a/main.py
+++ b/main.py
@@ -13,7 +13,8 @@ import subprocess
 
 if len(os.sys.argv) < 2:
     # CONFIG_JSON = "config/debugging.json"
-    CONFIG_JSON = "config/debugging-contemporaneous.json"
+    # CONFIG_JSON = "config/debugging-contemporaneous.json"
+    CONFIG_JSON = "config/debugging-measurement-times.json"
 else:
     CONFIG_JSON = os.sys.argv[1]
 
@@ -29,6 +30,19 @@ NUM_SIMS = CONFIG["num-simulations"]
 SIM_DIR = f"out/{CONFIG['simulation-name']}/simulation/remaster"
 SIM_PICKLE_DIR = f"out/{CONFIG['simulation-name']}/simulation/pickle"
 DB_PATH = f"out/{CONFIG['simulation-name']}/{CONFIG['output-hdf5']}"
+
+
+# ADDED 21-8: add in an optional time interval parameter to report tree data over time
+if not CONFIG["simulation-hyperparameters"].get("report-temporal-data", False):
+    REPORT_TEMPORAL_DATA = False
+else:
+    REPORT_TEMPORAL_DATA = True
+    try:
+        NUM_TEMP_MEASUREMENTS = CONFIG["simulation-hyperparameters"]["num-temp-measurements"]
+    except KeyError:
+        raise Exception("Check configuration: num-temp-measurements must be specified")
+####
+
 
 
 def prompt_user(message):
@@ -286,10 +300,10 @@ def run_beast2_simulations_parallel(simulation_xml_list, num_jobs):
         $ ./lib/beast/bin/beast -seed 1 -overwrite <simulation_xml>
         """
         print(f"Running simulation: {simulation_xml}")
-        command = ["./lib/beast/bin/beast", "-seed", "1", "-overwrite", simulation_xml]
+        command = ["/Applications/BEAST 2.7.6/bin/beast", "-seed", "1", "-overwrite", simulation_xml]
         try:
             result = subprocess.run(
-                command, check=True, capture_output=True, text=True, timeout=300
+                command, check=True, capture_output=True, text=True, timeout=300,
             )
             return result.stdout
         except subprocess.TimeoutExpired:
@@ -310,7 +324,9 @@ def run_beast2_simulations_parallel(simulation_xml_list, num_jobs):
                 print(f"Simulation generated an exception for {xml}: {exc}")
 
 
-def read_simulation_results(simulation_xml):
+
+# EDITED 21-8: also gets passed params to enable r0 temporal data to be reported
+def read_simulation_results(simulation_xml, params):
     sim_xml_obj = etree.parse(simulation_xml)
     sx = sim_xml_obj.getroot()
     tree_file = sx.xpath(".//logger[@mode='tree']")[0].attrib["fileName"]
@@ -333,22 +349,63 @@ def read_simulation_results(simulation_xml):
     last_X = last_rows[last_rows["population"] == "X"]["value"].values[0]
     last_Psi = last_rows[last_rows["population"] == "Psi"]["value"].values[0]
     last_Mu = last_rows[last_rows["population"] == "Mu"]["value"].values[0]
-    return {
+    sim_result_structure = {
         "tree": tree,
         "tree_height": max(tree.depths().values()),
         "present": last_psi_time,
         "present_prevalence": last_X,
-        "present_cumulative": last_Psi + last_Mu + last_X,
+        "present_cumulative": last_Psi + last_Mu + last_X
     }
+    
+    # ADDED 21-8: optionally report rzero, prevalence, cumul.
+    # infections, rzero over time here as a numpy recarray
+    if REPORT_TEMPORAL_DATA:
+    
+        meas_times = np.sort(np.random.uniform(low=0.0, high=sim_result_structure["present"],
+                                       size=NUM_TEMP_MEASUREMENTS))
+        r0_change_times = pd.Series(params["r0"]["change_times"])
+        
+        temp_data_headers = ["measurement-times", "prevalence", "cumulative", "reproductive-number"]
+        temp_data = [None for _ in range(NUM_TEMP_MEASUREMENTS)]
+        
+        for time_ind in range(NUM_TEMP_MEASUREMENTS):
+        
+            this_meas_time = meas_times[time_ind]
+        
+            most_recent_obs_time = traj_df[traj_df["t"] >= this_meas_time]["t"].min()
+            rows_this_time = traj_df[traj_df["t"] == most_recent_obs_time]
+            this_X = rows_this_time[rows_this_time["population"] == "X"]["value"].values[0]
+            this_Psi = rows_this_time[rows_this_time["population"] == "Psi"]["value"].values[0]
+            this_Mu = rows_this_time[rows_this_time["population"] == "Mu"]["value"].values[0]
+            
+            prev_meas_this_time = this_X
+            cumul_meas_this_time = this_X + this_Mu + this_Psi
+            
+            num_r0_changes_so_far = len(r0_change_times[r0_change_times<=this_meas_time])
+            r0_meas_this_time = params["r0"]["values"][num_r0_changes_so_far]
+            
+            temp_data[time_ind] = (this_meas_time, prev_meas_this_time,
+                                   cumul_meas_this_time, r0_meas_this_time)
+
+        sim_result_structure["temporal_measurements"] = np.rec.fromrecords(temp_data,
+                                                        names=",".join(head for head in temp_data_headers))
+        
+    return sim_result_structure
+
+
+
 
 
 def pickle_simulation_result(sim_pickle, sim_xml, params):
     tree_file = os.path.basename(sim_xml).replace(".xml", ".tree")
     if os.path.exists(f"{SIM_DIR}/{tree_file}"):
+        # EDITED 21-8: now also passes params to read_simulation_results,
+        # enables r0 temporal data to be reported. NOTE: this information
+        # is passed out in params anyway
         result = {
             "parameters": params,
             "simulation_xml": sim_xml,
-            "simulation_results": read_simulation_results(sim_xml),
+            "simulation_results": read_simulation_results(sim_xml, params),
         }
         with open(sim_pickle, "wb") as f:
             pickle.dump(result, f)
@@ -391,6 +448,8 @@ def _tree_to_uint8(tree):
     return np.frombuffer(pickle.dumps(tree), dtype="uint8")
 
 
+
+# EDITED 21-8: includes temporal data
 def create_database(pickle_files):
     db_conn = h5py.File(DB_PATH, "w")
     parameter_keys = [
@@ -425,6 +484,13 @@ def create_database(pickle_files):
             params_grp.create_dataset(
                 "epidemic_duration", data=sim["parameters"]["epidemic_duration"]
             )
+            
+            #ADDED 21-8: save temporal data here
+            if REPORT_TEMPORAL_DATA:
+                params_grp.create_dataset("temporal_measurements",
+                                           data=sim["simulation_results"]["temporal_measurements"])
+            
+            
             for key in parameter_keys:
                 param_grp = params_grp.create_group(key)
                 param_grp.create_dataset(


### PR DESCRIPTION
Allows for temporal measurements to be captured if a flag, "report-temporal-data" is specified as "true" in the json config, and a number of temporal measurements, "num-temp-measurements" is given. In this case, the simulation draws that number of random observation times between the start of the epidemic and the present and at each time reports the time, the rzero, the current prevalence and the cumulative infections to date.