### PR TITLE
Implemented limited-time sampling (first pass)

### DIFF
--- a/config/debugging-limited-time-sampling.json
+++ b/config/debugging-limited-time-sampling.json
@@ -1,0 +1,19 @@
+{
+    "simulation_name": "debugging-limited-time-sampling",
+    "output_hdf5": "dataset-demo.hdf5",
+    "seed": 42,
+    "remaster_xml": "src/remaster-template.xml",
+    "num_simulations": 20,
+    "num_workers": 3,
+    "simulation_hyperparameters": {
+	"duration_range": [20, 40],
+	"num_changes": [1, 2],
+	"shrinkage_factor": 0.99,
+	"r0_bounds": [1.4, 1.6],
+	"net_rem_rate_bounds": [6.5, 7.5],
+	"sampling_prop_bounds": [0.10, 0.30],
+    "report_temporal_data": true,
+    "num_temp_measurements": 10,
+    "limited_time_sampling": true
+    }
+}

--- a/config/readme.org
+++ b/config/readme.org
@@ -114,6 +114,9 @@
         },
         "num-temp-measurements": {
             "type": "integer"
+        },
+        "limited_time_sampling": {
+            "type": "boolean"
         }
       },
       "required": [

--- a/config/simulation-charmander-limited-time.json
+++ b/config/simulation-charmander-limited-time.json
@@ -1,0 +1,19 @@
+{
+    "simulation_name": "sim-charmander-limited-time",
+    "output_hdf5": "dataset-charmander-limited-time.hdf5",
+    "seed": 42,
+    "remaster_xml": "src/remaster-template.xml",
+    "num_simulations": 1000,
+    "num_workers": 5,
+    "simulation_hyperparameters": {
+        "duration_range": [30, 50],
+        "num_changes": [1, 2],
+        "shrinkage_factor": 0.99,
+        "r0_bounds": [1.0, 2.0],
+        "net_rem_rate_bounds": [6.5, 7.5],
+        "sampling_prop_bounds": [0.10, 0.30],
+        "report_temporal_data": true,
+        "num_temp_measurements": 10,
+        "limited_time_sampling": true
+    }
+}

--- a/main.py
+++ b/main.py
@@ -41,10 +41,7 @@ else:
         ]
     except KeyError:
         raise Exception("Check configuration: num_temp_measurements must be specified")
-if not CONFIG["simulation_hyperparameters"].get("limited_time_sampling", False):
-    LIMITED_TIME_SAMPLING = False
-else:
-    LIMITED_TIME_SAMPLING = True
+LIMITED_TIME_SAMPLING = CONFIG["simulation_hyperparameters"].get("limited_time_sampling", False)
 
 
 def prompt_user(message):


### PR DESCRIPTION
Very simple first version of limited-time sampling as described in Issue #20. Implemented as follows:

- Config json files can now optionally include a boolean flag, `"limited_time_sampling"`. There are two new example config json files which incorporate this.
- If this is `true`, we set the `"sampling_prop"` field of the simulation parameter structure to have `"values"` `0.0` and a random value within the specified bounds, with a single value for `"change_times"` drawn randomly on a uniform distribution between zero and the duration of the epidemic. (Note this is an extremely simplified implementation, we can try cleverer distributions here later). This adjustment to the `"sampling_prop"` field propagates through to the `"death_rate"` and `"sampling_rate"`.
- If `"limited_time_sampling"` is not specified in the config json, `main.py` runs as before.