### PR TITLE
Rename limited time samples to bulbasaur etc

### DIFF
--- a/config/readme.org
+++ b/config/readme.org
@@ -1,16 +1,5 @@
 * Simulation configuration
 
-** Examples
-
-- =debugging.json= is a simple example of a configuration.
-- =debugging-limited-time-sampling.json= is an example demonstrating
-  the use of the =limited_time_sampling= flag.
-- =debugging-measurement-times.json= is an example demonstrating the
-  use of the =report_temporal_data= flag.
-- =simulation-charmander.json= small simulation
-- =simulation-charmeleon.json= medium simulation
-- =simulation-charizard.json= large simulation
-
 ** Notes
 
 - You can validate a simulation configuration against the schema using
@@ -30,11 +19,27 @@
   =integer=) must also be specified. This is the number of randomly
   selected time points between the start of the epidemic and the
   present at which data is reported.
-- =limited_time_sampling= is a boolean flag for whether to set the
-  initial sampling proportion to zero. The change point is a random
-  time uniformly distributed across the duration of the epidemic, and
-  the sampling proportion after that change point is uniformly
-  distributed between the bounds specified in the configuration.
+- =simulation-hyperparameters.limited_time_sampling= can be set to
+  =true= in order to implement sampling over limited time only
+  (=false= by default). If this parameter is set to =true=, the
+  sampling proportion is zero until a random change point, uniformly
+  distributed over the duration of the epidemic. If =false=, the
+  sampling proportion is nonzero throughout and changes in sync 
+  with the other parameters of the epidemic.
+
+** Examples
+
+- =debugging.json= is a simple example of a configuration.
+- =debugging-limited-time-sampling.json= is an example demonstrating
+  the use of the =limited_time_sampling= flag.
+- =debugging-measurement-times.json= is an example demonstrating the
+  use of the =report_temporal_data= flag.
+- =simulation-charmander.json= small simulation
+- =simulation-charmeleon.json= medium simulation
+- =simulation-charizard.json= large simulation
+- =simulation-bulbasaur.json= small simulation with limited-time sampling
+- =simulation-ivysaur.json= medium simulation with limited-time sampling
+- =simulation-venusaur.json= large simulation with limited-time sampling
 
 ** Schema
 

--- a/config/simulation-bulbasaur.json
+++ b/config/simulation-bulbasaur.json
@@ -1,6 +1,6 @@
 {
-    "simulation_name": "sim-charmander-limited-time",
-    "output_hdf5": "dataset-charmander-limited-time.hdf5",
+    "simulation_name": "sim-bulbasaur",
+    "output_hdf5": "dataset-bulbasaur.hdf5",
     "seed": 42,
     "remaster_xml": "src/remaster-template.xml",
     "num_simulations": 1000,

--- a/config/simulation-ivysaur.json
+++ b/config/simulation-ivysaur.json
@@ -1,0 +1,19 @@
+{
+    "simulation_name": "sim-ivysaur",
+    "output_hdf5": "dataset-ivysaur.hdf5",
+    "seed": 42,
+    "remaster_xml": "src/remaster-template.xml",
+    "num_simulations": 2000,
+    "num_workers": 5,
+    "simulation_hyperparameters": {
+        "duration_range": [30, 50],
+        "num_changes": [1, 2],
+        "shrinkage_factor": 0.50,
+        "r0_bounds": [1.0, 3.0],
+        "net_rem_rate_bounds": [5.0, 9.0],
+        "sampling_prop_bounds": [0.05, 0.50],
+        "report_temporal_data": true,
+        "num_temp_measurements": 10,
+        "limited_time_sampling": true
+    }
+}

--- a/config/simulation-venusaur.json
+++ b/config/simulation-venusaur.json
@@ -1,0 +1,19 @@
+{
+    "simulation_name": "sim-venusaur",
+    "output_hdf5": "dataset-venusaur.hdf5",
+    "seed": 42,
+    "remaster_xml": "src/remaster-template.xml",
+    "num_simulations": 11000,
+    "num_workers": 5,
+    "simulation_hyperparameters": {
+        "duration_range": [30, 90],
+        "num_changes": [1, 2],
+        "shrinkage_factor": 0.25,
+        "r0_bounds": [0.5, 3.0],
+        "net_rem_rate_bounds": [5.0, 9.0],
+        "sampling_prop_bounds": [0.05, 0.50],
+	    "report_temporal_data": true,
+        "num_temp_measurements": 10,
+        "limited_time_sampling": true
+    }
+}


### PR DESCRIPTION
Renames the limited time simulation configs, study names, directories etc to be bulbasaur/ivysaur/venusaur. Also updates the readme.