### PR TITLE
Fix change point selection

### DIFF
--- a/config/simulation-bulbasaur-50.json
+++ b/config/simulation-bulbasaur-50.json
@@ -1,0 +1,38 @@
+{
+    "simulation_name": "sim-bulbasaur-50",
+    "output_hdf5": "dataset-bulbasaur-50.hdf5",
+    "seed": 42,
+    "remaster_xml": "src/remaster-template.xml",
+    "num_simulations": 1000,
+    "num_workers": 5,
+    "simulation_hyperparameters": {
+        "duration_range": {
+            "dist": "uniform_int",
+            "lower_bound": 30,
+            "upper_bound": 50
+        },
+        "num_changes": {
+            "dist": "uniform_int",
+            "lower_bound": 1,
+            "upper_bound": 2
+        },
+        "r0": {
+            "dist": "lognormal",
+            "LN_mean": 0.91,
+            "LN_sigma": 0.1
+        },
+        "net_removal_rate": {
+            "dist": "lognormal",
+            "LN_mean": -1.80,
+            "LN_sigma": 0.1
+        },
+        "sampling_prop": {
+            "dist": "uniform",
+            "lower_bound": 0.1,
+            "upper_bound": 0.3
+        },
+        "num_temp_measurements": 10,
+        "limited_time_sampling": true,
+        "sampling_activation_time": 0.5
+    }
+}

--- a/config/simulation-bulbasaur-90.json
+++ b/config/simulation-bulbasaur-90.json
@@ -1,0 +1,38 @@
+{
+    "simulation_name": "sim-bulbasaur-90",
+    "output_hdf5": "dataset-bulbasaur-90.hdf5",
+    "seed": 42,
+    "remaster_xml": "src/remaster-template.xml",
+    "num_simulations": 1000,
+    "num_workers": 5,
+    "simulation_hyperparameters": {
+        "duration_range": {
+            "dist": "uniform_int",
+            "lower_bound": 30,
+            "upper_bound": 50
+        },
+        "num_changes": {
+            "dist": "uniform_int",
+            "lower_bound": 1,
+            "upper_bound": 2
+        },
+        "r0": {
+            "dist": "lognormal",
+            "LN_mean": 0.91,
+            "LN_sigma": 0.1
+        },
+        "net_removal_rate": {
+            "dist": "lognormal",
+            "LN_mean": -1.80,
+            "LN_sigma": 0.1
+        },
+        "sampling_prop": {
+            "dist": "uniform",
+            "lower_bound": 0.1,
+            "upper_bound": 0.3
+        },
+        "num_temp_measurements": 10,
+        "limited_time_sampling": true,
+        "sampling_activation_time": 0.9
+    }
+}

--- a/main.py
+++ b/main.py
@@ -163,10 +163,11 @@ def _rand_remaster_params_serial(p, hyperparams):
                 raise NotImplementedError(
                     "Only 'uniform' and 'beta' distributions supported for sampling_prop in limited time sampling"
                 )
-        # TODO: this just randomly selects ANY time uniformly - should be more specific
-        change_times_arr = np.array(
-            [p["epidemic_duration"] * np.random.uniform()]
-        )
+        if SPECIFIC_SAMPLING_ACTIVATION_TIME:
+            activation_time = SAMPLING_ACTIVATION_TIME * p["epidemic_duration"]
+        else:
+            activation_time = np.random.uniform(0.0, p["epidemic_duration"])
+        change_times_arr = np.array([activation_time])
         p["sampling_prop"] = {
                 "values": np.array([0.0, sampling_prop_values[0]]),
                 "change_times": change_times_arr,

--- a/main.py
+++ b/main.py
@@ -29,6 +29,13 @@ SIM_PICKLE_DIR = f"out/{CONFIG['simulation_name']}/simulation/pickle"
 DB_PATH = f"out/{CONFIG['simulation_name']}/{CONFIG['output_hdf5']}"
 NUM_TEMP_MEASUREMENTS = CONFIG["simulation_hyperparameters"]["num_temp_measurements"]
 LIMITED_TIME_SAMPLING = CONFIG["simulation_hyperparameters"].get("limited_time_sampling", False)
+if LIMITED_TIME_SAMPLING:
+    if "sampling_activation_time" in CONFIG["simulation_hyperparameters"].keys():
+        SPECIFIC_SAMPLING_ACTIVATION_TIME = True
+        SAMPLING_ACTIVATION_TIME = CONFIG["simulation_hyperparameters"]["sampling_activation_time"]
+        assert (0.0 <= SAMPLING_ACTIVATION_TIME <= 1.0), "sampling_activation_time must be between 0.0 and 1.0"
+    else:
+        SPECIFIC_SAMPLING_ACTIVATION_TIME = False
 
 
 def prompt_user(message):


### PR DESCRIPTION
Slightly adjusts the simulation setup so that, when running a limited-time sampling simulation (i.e. `"limited_time_sampling"=true`) in the config, you can optionally also specify `sampling_activation_time` in the config. This is a float between 0.0 and 1.0 such that at `sampling_activation_time * p[`epidemic_duration`]`, the sampling proportion changes from zero to a value drawn from its prior distribution.